### PR TITLE
fix: client embedding extraction dimensions mismatch

### DIFF
--- a/frontend/src/components/MatchResult.tsx
+++ b/frontend/src/components/MatchResult.tsx
@@ -26,10 +26,15 @@ export function MatchResult({ image, onReset, onBack, initialResult, onResult }:
     try {
       // Try to extract embedding on device (optional optimization)
       let embedding: number[] | undefined;
+      let embeddingError: string | undefined;
       try {
         embedding = await getEmbeddingFromBase64(image);
+        console.log('[MatchResult] Successfully extracted embedding:', embedding?.length, 'dimensions');
       } catch (e) {
-        console.log('Client embedding extraction failed, using server-side:', e);
+        embeddingError = e instanceof Error ? e.message : 'Unknown error';
+        console.error('[MatchResult] Client embedding extraction failed:', embeddingError);
+        // Don't proceed without embedding since backend doesn't support server-side extraction yet
+        throw new Error(`Embedding extraction failed: ${embeddingError}`);
       }
 
       // Send to API for matching


### PR DESCRIPTION
## Summary

Fixes #13 - Client Embedding Extraction Debugging

### Problem
- MobileNet V2 mit alpha=1.0 produzierte 1280-dim Embeddings
- Backend erwartete 1024-dim → Validierung schlug fehl
- Fehler wurden stillschweigend ignoriert

### Changes
- **frontend/src/services/embedding.ts**
  - MobileNet alpha auf 0.75 geändert (→ 1024-dim)
  - Korrektes Tensor-Flattening hinzugefügt
  - Besseres Error-Handling mit expliziten Throws

- **backend/src/routes/images.ts**
  - Flexible Validierung für 1024 oder 1280 Dimensionen

- **frontend/src/components/MatchResult.tsx**
  - Fehler werden im UI angezeigt statt nur geloggt

### Test Plan
- [ ] App starten, Foto machen
- [ ] Embedding-Extraktion sollte funktionieren
- [ ] Bei Fehler: Meldung im UI sichtbar

🤖 Generated by ResearchAgent