### PR TITLE
fix: TensorFlow.js Backend-Initialisierung

### DIFF
--- a/frontend/src/services/embedding.ts
+++ b/frontend/src/services/embedding.ts
@@ -14,6 +14,16 @@ export function getLastModelError(): string | null {
 export async function loadEmbeddingModel(): Promise<void> {
   if (model) return;
   
+  // Initialize TensorFlow.js backend before loading model
+  // This fixes 'No backend found in registry' error in Capacitor/React apps
+  try {
+    await tf.setBackend('cpu');
+    await tf.ready();
+    console.log('[Embedding] TensorFlow.js backend initialized:', tf.getBackend());
+  } catch (backendError) {
+    console.warn('[Embedding] Failed to set CPU backend:', backendError);
+  }
+  
   modelLoadError = null;
   
   try {


### PR DESCRIPTION
## Problem
TensorFlow.js hat kein Backend registriert (WebGL, WASM oder CPU). Dieser Fehler tritt oft in React/Capacitor-Apps auf.

## Lösung
Explizite Backend-Initialisierung in `frontend/src/services/embedding.ts`:

- Backend wird auf 'cpu' gesetzt (funktioniert immer)
- `tf.ready()\ wartet auf Backend-Initialisierung
- Try/catch für graceful fallback

## Änderungen
- Backend-Initialisierung am Anfang der `loadEmbeddingModel()` Funktion
- Logging zur besseren Debuggability

## Testing
- Build erfolgreich: `npm run build` ✅
- Keine Breaking Changes

Fixes: `No backend found in registry` Fehler