### PR TITLE
fix: remove duplicate View import in ScanScreen

### DIFF
--- a/frontend/src/screens/scan/ScanScreen.tsx
+++ b/frontend/src/screens/scan/ScanScreen.tsx
@@ -14,7 +14,7 @@ import {
 } from 'react-native';
 import { MaterialCommunityIcons } from '@expo/vector-icons';
 import { CameraView, useCameraPermissions } from "expo-camera";
-import { Button, View } from "react-native";
+import { Button } from "react-native";
 import type { NativeStackScreenProps } from '@react-navigation/native-stack';
 import type { ScanStackParamList } from '../../types/navigation';
 import { useScan } from '../../stores';


### PR DESCRIPTION
Fixes build error: Identifier 'View' has already been declared.

The View component was imported twice:
- Once in the main react-native import block (line 6-12)
- Again in a separate import statement (line 17) when Button was added

This PR removes the duplicate View import, keeping only Button in the second import.