### PR TITLE
feat(backend): Production fixes - auth, rate limiting, tests, health

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -5,6 +5,15 @@ DATABASE_URL=postgresql://tauben:your_secure_password@localhost:5432/tauben_scan
 PORT=3000
 NODE_ENV=production
 
+# API Key Authentication (REQUIRED for production)
+# Generate with: node scripts/generate-api-key.js
+API_KEY=your_secure_api_key_here_min_32_characters
+
+# Rate Limiting Configuration
+RATE_LIMIT_WINDOW_MS=900000
+RATE_LIMIT_MAX_REQUESTS=100
+RATE_LIMIT_UPLOAD_MAX=10
+
 # CORS Configuration (comma-separated list of allowed origins)
 # For local development:
 CORS_ORIGINS=http://localhost:5173,http://localhost:3000
@@ -12,5 +21,9 @@ CORS_ORIGINS=http://localhost:5173,http://localhost:3000
 # CORS_ORIGINS=capacitor://localhost,http://localhost
 
 # Security
-# Generate with: openssl rand -base64 32
+# JWT_SECRET is used if you need JWT tokens in addition to API keys
 JWT_SECRET=your_jwt_secret_here
+
+# Health Check Configuration
+# Set to true to require API key for health endpoints (default: false)
+REQUIRE_AUTH_FOR_HEALTH=false

--- a/backend/.env.test
+++ b/backend/.env.test
@@ -1,0 +1,6 @@
+# Test environment configuration
+NODE_ENV=test
+API_KEY=test_api_key_for_testing_12345678901234567890123456789012345678901234
+DATABASE_URL=postgresql://tauben:test@localhost:5432/tauben_scanner_test
+PORT=3001
+REQUIRE_AUTH_FOR_HEALTH=false

--- a/backend/__tests__/auth.test.ts
+++ b/backend/__tests__/auth.test.ts
@@ -1,0 +1,103 @@
+import { describe, it, expect, beforeEach, afterEach } from '@jest/globals';
+import { validateApiKey, optionalAuth, requirePermission, AuthenticatedRequest, API_KEYS } from '../src/middleware/auth';
+import { Request, Response, NextFunction } from 'express';
+
+describe('Auth Middleware', () => {
+  let req: Partial<AuthenticatedRequest>;
+  let res: Partial<Response>;
+  let next: NextFunction;
+  
+  beforeEach(() => {
+    req = {
+      headers: {},
+      path: '/api/pigeons',
+    };
+    res = {
+      status: jest.fn().mockReturnThis(),
+      json: jest.fn().mockReturnThis(),
+    };
+    next = jest.fn();
+    
+    // Set up test API key
+    process.env.API_KEY = 'test_api_key_12345678901234567890123456789012345678901234';
+    API_KEYS.clear();
+    API_KEYS.set(process.env.API_KEY, {
+      id: 'test',
+      name: 'Test Key',
+      key: process.env.API_KEY,
+      permissions: ['read', 'write'],
+      createdAt: new Date(),
+    });
+  });
+  
+  afterEach(() => {
+    delete process.env.API_KEY;
+    API_KEYS.clear();
+  });
+
+  describe('validateApiKey', () => {
+    it('should skip auth for health endpoints', () => {
+      req.path = '/health';
+      validateApiKey(req as AuthenticatedRequest, res as Response, next);
+      
+      expect(next).toHaveBeenCalled();
+      expect(res.status).not.toHaveBeenCalled();
+    });
+    
+    it('should return 401 if no API key provided', () => {
+      validateApiKey(req as AuthenticatedRequest, res as Response, next);
+      
+      expect(res.status).toHaveBeenCalledWith(401);
+      expect(res.json).toHaveBeenCalledWith(
+        expect.objectContaining({
+          error: 'UNAUTHORIZED',
+        })
+      );
+    });
+    
+    it('should authenticate with X-API-Key header', () => {
+      req.headers = { 'x-api-key': process.env.API_KEY };
+      validateApiKey(req as AuthenticatedRequest, res as Response, next);
+      
+      expect(next).toHaveBeenCalled();
+      expect(req.apiKey).toBeDefined();
+      expect(req.apiKey?.id).toBe('test');
+    });
+    
+    it('should authenticate with Authorization: Bearer header', () => {
+      req.headers = { 'authorization': `Bearer ${process.env.API_KEY}` };
+      validateApiKey(req as AuthenticatedRequest, res as Response, next);
+      
+      expect(next).toHaveBeenCalled();
+      expect(req.apiKey).toBeDefined();
+    });
+  });
+  
+  describe('requirePermission', () => {
+    it('should allow access with correct permission', () => {
+      req.apiKey = {
+        id: 'test',
+        name: 'Test Key',
+        permissions: ['read'],
+      };
+      
+      const middleware = requirePermission('read');
+      middleware(req as AuthenticatedRequest, res as Response, next);
+      
+      expect(next).toHaveBeenCalled();
+    });
+    
+    it('should deny access without permission', () => {
+      req.apiKey = {
+        id: 'test',
+        name: 'Test Key',
+        permissions: ['read'],
+      };
+      
+      const middleware = requirePermission('delete');
+      middleware(req as AuthenticatedRequest, res as Response, next);
+      
+      expect(res.status).toHaveBeenCalledWith(403);
+    });
+  });
+});

--- a/backend/__tests__/health.test.ts
+++ b/backend/__tests__/health.test.ts
@@ -1,0 +1,50 @@
+import { describe, it, expect } from '@jest/globals';
+import request from 'supertest';
+import express from 'express';
+import healthRouter from '../src/routes/health';
+
+const app = express();
+app.use(express.json());
+app.use('/health', healthRouter);
+
+describe('Health Routes', () => {
+  describe('GET /health', () => {
+    it('should return health status', async () => {
+      const response = await request(app)
+        .get('/health')
+        .expect('Content-Type', /json/);
+      
+      // Response status depends on database connection
+      expect(response.status).toBe(200);
+      expect(response.body).toHaveProperty('status');
+      expect(response.body).toHaveProperty('timestamp');
+    });
+  });
+  
+  describe('GET /health/live', () => {
+    it('should return alive status', async () => {
+      const response = await request(app)
+        .get('/health/live')
+        .expect(200)
+        .expect('Content-Type', /json/);
+      
+      expect(response.body.status).toBe('alive');
+      expect(response.body.timestamp).toBeDefined();
+    });
+  });
+  
+  describe('GET /health/detailed', () => {
+    it('should return detailed health status', async () => {
+      const response = await request(app)
+        .get('/health/detailed')
+        .expect('Content-Type', /json/);
+      
+      expect(response.body).toHaveProperty('status');
+      expect(response.body).toHaveProperty('timestamp');
+      expect(response.body).toHaveProperty('version');
+      expect(response.body).toHaveProperty('uptime');
+      expect(response.body).toHaveProperty('services');
+      expect(response.body).toHaveProperty('checks');
+    });
+  });
+});

--- a/backend/__tests__/integration.test.ts
+++ b/backend/__tests__/integration.test.ts
@@ -1,0 +1,84 @@
+import { describe, it, expect, beforeAll, afterAll } from '@jest/globals';
+import request from 'supertest';
+
+// These tests require a running server with database
+// Skip in CI if database is not available
+describe('Integration Tests', () => {
+  const baseUrl = process.env.TEST_API_URL || 'http://localhost:3000';
+  const apiKey = process.env.TEST_API_KEY || 'test-key';
+  
+  beforeAll(() => {
+    // Setup code
+  });
+  
+  afterAll(() => {
+    // Cleanup code
+  });
+  
+  describe('API Authentication', () => {
+    it('should reject requests without API key', async () => {
+      const response = await request(baseUrl)
+        .get('/api/pigeons');
+      
+      expect(response.status).toBe(401);
+      expect(response.body).toHaveProperty('error');
+    });
+    
+    it('should accept requests with valid X-API-Key header', async () => {
+      const response = await request(baseUrl)
+        .get('/api/pigeons')
+        .set('X-API-Key', apiKey);
+      
+      expect([200, 401]).toContain(response.status);
+    });
+    
+    it('should accept requests with valid Authorization Bearer header', async () => {
+      const response = await request(baseUrl)
+        .get('/api/pigeons')
+        .set('Authorization', `Bearer ${apiKey}`);
+      
+      expect([200, 401]).toContain(response.status);
+    });
+  });
+  
+  describe('Rate Limiting', () => {
+    it('should include rate limit headers in response', async () => {
+      const response = await request(baseUrl)
+        .get('/health');
+      
+      expect(response.headers).toHaveProperty('x-ratelimit-limit');
+    });
+  });
+  
+  describe('Health Endpoints', () => {
+    it('should return health status', async () => {
+      const response = await request(baseUrl)
+        .get('/health');
+      
+      expect(response.status).toBe(200);
+      expect(response.body).toHaveProperty('status');
+    });
+    
+    it('should return detailed health status', async () => {
+      const response = await request(baseUrl)
+        .get('/health/detailed');
+      
+      expect(response.body).toHaveProperty('services');
+    });
+    
+    it('should return liveness check', async () => {
+      const response = await request(baseUrl)
+        .get('/health/live');
+      
+      expect(response.status).toBe(200);
+      expect(response.body.status).toBe('alive');
+    });
+    
+    it('should return readiness check', async () => {
+      const response = await request(baseUrl)
+        .get('/health/ready');
+      
+      expect(response.body).toHaveProperty('status');
+    });
+  });
+});

--- a/backend/__tests__/rateLimit.test.ts
+++ b/backend/__tests__/rateLimit.test.ts
@@ -1,0 +1,77 @@
+import { describe, it, expect, beforeEach, afterEach } from '@jest/globals';
+import { createRateLimiter, apiRateLimiter, rateLimitStore, cleanupExpiredEntries } from '../src/middleware/rateLimit';
+import { Request, Response } from 'express';
+
+describe('Rate Limit Middleware', () => {
+  beforeEach(() => {
+    rateLimitStore.clear();
+  });
+  
+  afterEach(() => {
+    rateLimitStore.clear();
+  });
+  
+  describe('createRateLimiter', () => {
+    it('should allow requests under the limit', () => {
+      const limiter = createRateLimiter({
+        windowMs: 60000,
+        maxRequests: 5,
+      });
+      
+      const req = {
+        headers: {},
+        ip: '127.0.0.1',
+        path: '/api/test',
+        socket: { remoteAddress: '127.0.0.1' },
+      } as Partial<Request>;
+      
+      let nextCalled = false;
+      
+      limiter(req as Request, {} as Response, () => { nextCalled = true; });
+      
+      expect(nextCalled).toBe(true);
+    });
+    
+    it('should block requests over the limit', () => {
+      const limiter = createRateLimiter({
+        windowMs: 60000,
+        maxRequests: 2,
+      });
+      
+      const req = {
+        headers: {},
+        ip: '127.0.0.1',
+        path: '/api/test',
+        socket: { remoteAddress: '127.0.0.1' },
+      } as Partial<Request>;
+      
+      const res = {
+        status: jest.fn().mockReturnThis(),
+        json: jest.fn().mockReturnThis(),
+        setHeader: jest.fn(),
+      } as unknown as Response;
+      
+      // First 2 requests should pass
+      limiter(req as Request, res, () => {});
+      limiter(req as Request, res, () => {});
+      
+      // Third request should be blocked
+      limiter(req as Request, res, () => {});
+      
+      expect(res.status).toHaveBeenCalledWith(429);
+    });
+  });
+  
+  describe('cleanupExpiredEntries', () => {
+    it('should remove expired entries', () => {
+      rateLimitStore.set('test-key', {
+        count: 1,
+        resetTime: Date.now() - 1000, // Expired 1 second ago
+      });
+      
+      cleanupExpiredEntries();
+      
+      expect(rateLimitStore.has('test-key')).toBe(false);
+    });
+  });
+});

--- a/backend/__tests__/setup.ts
+++ b/backend/__tests__/setup.ts
@@ -1,0 +1,16 @@
+// Test setup file
+import { jest } from '@jest/globals';
+
+// Set test environment
+process.env.NODE_ENV = 'test';
+process.env.API_KEY = 'test_api_key_for_testing_12345678901234567890123456789012345678901234';
+
+// Mock console methods during tests (optional)
+// global.console = {
+//   ...console,
+//   log: jest.fn(),
+//   debug: jest.fn(),
+//   info: jest.fn(),
+//   warn: jest.fn(),
+//   error: jest.fn(),
+// };

--- a/backend/jest.config.js
+++ b/backend/jest.config.js
@@ -1,0 +1,16 @@
+module.exports = {
+  preset: 'ts-jest',
+  testEnvironment: 'node',
+  roots: ['<rootDir>/__tests__'],
+  testMatch: ['**/*.test.ts'],
+  transform: {
+    '^.+\\.tsx?$': 'ts-jest',
+  },
+  collectCoverageFrom: [
+    'src/**/*.ts',
+    '!src/index.ts',
+    '!src/config/**',
+  ],
+  coverageDirectory: 'coverage',
+  setupFiles: ['<rootDir>/.env.test'],
+};

--- a/backend/package.json
+++ b/backend/package.json
@@ -7,7 +7,11 @@
     "build": "tsc",
     "start": "node dist/index.js",
     "dev": "nodemon src/index.ts",
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "test": "jest",
+    "test:watch": "jest --watch",
+    "test:coverage": "jest --coverage",
+    "test:integration": "jest __tests__/integration.test.ts",
+    "generate-api-key": "node scripts/generate-api-key.js"
   },
   "keywords": [
     "tauben",
@@ -30,12 +34,18 @@
     "pg": "^8.18.0"
   },
   "devDependencies": {
+    "@jest/globals": "^29.7.0",
     "@types/cors": "^2.8.19",
     "@types/express": "^5.0.6",
+    "@types/jest": "^29.5.0",
     "@types/morgan": "^1.9.10",
     "@types/node": "^25.3.0",
     "@types/pg": "^8.16.0",
+    "@types/supertest": "^6.0.0",
+    "jest": "^29.7.0",
     "nodemon": "^3.1.14",
+    "supertest": "^6.3.0",
+    "ts-jest": "^29.1.0",
     "ts-node": "^10.9.2",
     "typescript": "^5.9.3"
   }

--- a/backend/scripts/generate-api-key.js
+++ b/backend/scripts/generate-api-key.js
@@ -1,0 +1,38 @@
+// scripts/generate-api-key.js - Generate secure API keys
+const crypto = require('crypto');
+
+function generateApiKey(length = 64) {
+  return crypto.randomBytes(length).toString('hex');
+}
+
+function main() {
+  console.log('=== API Key Generator ===\n');
+  
+  const key = generateApiKey();
+  const shortKey = key.substring(0, 32) + '...';
+  
+  console.log('Generated API Key:');
+  console.log('------------------');
+  console.log(key);
+  console.log('------------------\n');
+  
+  console.log('Add this to your .env file:');
+  console.log(`API_KEY=${key}\n`);
+  
+  console.log('Usage with curl:');
+  console.log(`curl -H "X-API-Key: ${key}" http://localhost:3000/api/pigeons\n`);
+  
+  console.log('Usage with Authorization header:');
+  console.log(`curl -H "Authorization: Bearer ${key}" http://localhost:3000/api/pigeons\n`);
+  
+  console.log('Key details:');
+  console.log(`- Length: ${key.length} characters`);
+  console.log(`- Format: Hex encoded random bytes`);
+  console.log(`- Preview: ${shortKey}`);
+}
+
+if (require.main === module) {
+  main();
+}
+
+module.exports = { generateApiKey };

--- a/backend/src/middleware/auth.ts
+++ b/backend/src/middleware/auth.ts
@@ -1,0 +1,147 @@
+// auth.ts - API Key Authentication Middleware
+import { Request, Response, NextFunction } from 'express';
+
+// Extend Express Request to include apiKey
+export interface AuthenticatedRequest extends Request {
+  apiKey?: {
+    id: string;
+    name: string;
+    permissions: string[];
+  };
+}
+
+// In-memory API key storage (in production, use database)
+const API_KEYS = new Map<string, {
+  id: string;
+  name: string;
+  key: string;
+  permissions: string[];
+  createdAt: Date;
+  lastUsedAt?: Date;
+}>();
+
+// Initialize with API key from environment
+function initializeApiKeys(): void {
+  const envKey = process.env.API_KEY;
+  if (envKey && envKey.length >= 32) {
+    API_KEYS.set(envKey, {
+      id: 'default',
+      name: 'Default API Key',
+      key: envKey,
+      permissions: ['read', 'write', 'delete', 'admin'],
+      createdAt: new Date(),
+    });
+    console.log('API Key authentication initialized');
+  } else {
+    console.warn('No valid API_KEY configured. Set a secure API_KEY with at least 32 characters.');
+  }
+}
+
+// Initialize on module load
+initializeApiKeys();
+
+export function validateApiKey(req: AuthenticatedRequest, res: Response, next: NextFunction): void {
+  if (req.path === '/health' || req.path === '/health/') {
+    const requireAuthForHealth = process.env.REQUIRE_AUTH_FOR_HEALTH === 'true';
+    if (!requireAuthForHealth) {
+      return next();
+    }
+  }
+
+  const apiKeyHeader = req.headers['x-api-key'] as string;
+  const authHeader = req.headers['authorization'] as string;
+  
+  let providedKey: string | undefined;
+  
+  if (apiKeyHeader) {
+    providedKey = apiKeyHeader.trim();
+  } else if (authHeader && authHeader.toLowerCase().startsWith('bearer ')) {
+    providedKey = authHeader.slice(7).trim();
+  }
+  
+  if (!providedKey) {
+    res.status(401).json({
+      error: 'UNAUTHORIZED',
+      message: 'API key is required. Provide it via X-API-Key header or Authorization: Bearer <key>',
+    });
+    return;
+  }
+  
+  const keyData = API_KEYS.get(providedKey);
+  if (!keyData) {
+    res.status(401).json({
+      error: 'UNAUTHORIZED',
+      message: 'Invalid API key',
+    });
+    return;
+  }
+  
+  if (providedKey.length < 32) {
+    res.status(401).json({
+      error: 'UNAUTHORIZED',
+      message: 'API key must be at least 32 characters',
+    });
+    return;
+  }
+  
+  keyData.lastUsedAt = new Date();
+  
+  req.apiKey = {
+    id: keyData.id,
+    name: keyData.name,
+    permissions: keyData.permissions,
+  };
+  
+  next();
+}
+
+export function requirePermission(permission: string) {
+  return (req: AuthenticatedRequest, res: Response, next: NextFunction): void => {
+    if (!req.apiKey) {
+      res.status(401).json({
+        error: 'UNAUTHORIZED',
+        message: 'Authentication required',
+      });
+      return;
+    }
+    
+    if (!req.apiKey.permissions.includes(permission) && !req.apiKey.permissions.includes('admin')) {
+      res.status(403).json({
+        error: 'FORBIDDEN',
+        message: `Permission '${permission}' required`,
+      });
+      return;
+    }
+    
+    next();
+  };
+}
+
+export function optionalAuth(req: AuthenticatedRequest, res: Response, next: NextFunction): void {
+  const apiKeyHeader = req.headers['x-api-key'] as string;
+  const authHeader = req.headers['authorization'] as string;
+  
+  let providedKey: string | undefined;
+  
+  if (apiKeyHeader) {
+    providedKey = apiKeyHeader.trim();
+  } else if (authHeader && authHeader.toLowerCase().startsWith('bearer ')) {
+    providedKey = authHeader.slice(7).trim();
+  }
+  
+  if (providedKey) {
+    const keyData = API_KEYS.get(providedKey);
+    if (keyData) {
+      keyData.lastUsedAt = new Date();
+      req.apiKey = {
+        id: keyData.id,
+        name: keyData.name,
+        permissions: keyData.permissions,
+      };
+    }
+  }
+  
+  next();
+}
+
+export { API_KEYS };

--- a/backend/src/middleware/rateLimit.ts
+++ b/backend/src/middleware/rateLimit.ts
@@ -1,0 +1,120 @@
+// rateLimit.ts - Rate Limiting Middleware
+import { Request, Response, NextFunction } from 'express';
+
+interface RateLimitConfig {
+  windowMs: number;
+  maxRequests: number;
+  keyGenerator?: (req: Request) => string;
+  handler?: (req: Request, res: Response) => void;
+}
+
+interface RateLimitEntry {
+  count: number;
+  resetTime: number;
+}
+
+const rateLimitStore = new Map<string, RateLimitEntry>();
+
+const DEFAULT_CONFIG: RateLimitConfig = {
+  windowMs: 15 * 60 * 1000,
+  maxRequests: 100,
+  keyGenerator: (req: Request): string => {
+    const apiKey = req.headers['x-api-key'] as string || 
+                   (req.headers['authorization'] || '').slice(7).trim();
+    if (apiKey) {
+      return `api:${apiKey}`;
+    }
+    return `ip:${req.ip || req.socket.remoteAddress || 'unknown'}:${req.path}`;
+  },
+};
+
+function cleanupExpiredEntries(): void {
+  const now = Date.now();
+  for (const [key, entry] of rateLimitStore.entries()) {
+    if (entry.resetTime <= now) {
+      rateLimitStore.delete(key);
+    }
+  }
+}
+
+setInterval(cleanupExpiredEntries, 5 * 60 * 1000);
+
+export function createRateLimiter(config: Partial<RateLimitConfig> = {}) {
+  const finalConfig = { ...DEFAULT_CONFIG, ...config };
+  
+  return (req: Request, res: Response, next: NextFunction): void => {
+    const now = Date.now();
+    const key = finalConfig.keyGenerator!(req);
+    
+    let entry = rateLimitStore.get(key);
+    
+    if (!entry || entry.resetTime <= now) {
+      entry = {
+        count: 0,
+        resetTime: now + finalConfig.windowMs,
+      };
+    }
+    
+    if (entry.count >= finalConfig.maxRequests) {
+      const retryAfter = Math.ceil((entry.resetTime - now) / 1000);
+      
+      if (finalConfig.handler) {
+        return finalConfig.handler(req, res);
+      }
+      
+      res.setHeader('Retry-After', retryAfter);
+      res.setHeader('X-RateLimit-Limit', finalConfig.maxRequests.toString());
+      res.setHeader('X-RateLimit-Remaining', '0');
+      res.setHeader('X-RateLimit-Reset', new Date(entry.resetTime).toISOString());
+      
+      res.status(429).json({
+        error: 'RATE_LIMIT_EXCEEDED',
+        message: `Rate limit exceeded. Try again in ${retryAfter} seconds.`,
+        retryAfter,
+      });
+      return;
+    }
+    
+    entry.count++;
+    rateLimitStore.set(key, entry);
+    
+    res.setHeader('X-RateLimit-Limit', finalConfig.maxRequests.toString());
+    res.setHeader('X-RateLimit-Remaining', (finalConfig.maxRequests - entry.count).toString());
+    res.setHeader('X-RateLimit-Window', `${finalConfig.windowMs / 1000}s`);
+    
+    next();
+  };
+}
+
+export const apiRateLimiter = createRateLimiter({
+  windowMs: 15 * 60 * 1000,
+  maxRequests: 100,
+});
+
+export const strictRateLimiter = createRateLimiter({
+  windowMs: 15 * 60 * 1000,
+  maxRequests: 20,
+});
+
+export const uploadRateLimiter = createRateLimiter({
+  windowMs: 5 * 60 * 1000,
+  maxRequests: 10,
+});
+
+export const authRateLimiter = createRateLimiter({
+  windowMs: 60 * 1000,
+  maxRequests: 5,
+  keyGenerator: (req: Request): string => {
+    return `auth:${req.ip || req.socket.remoteAddress || 'unknown'}`;
+  },
+});
+
+export const healthRateLimiter = createRateLimiter({
+  windowMs: 60 * 1000,
+  maxRequests: 30,
+  keyGenerator: (req: Request): string => {
+    return `health:${req.ip || req.socket.remoteAddress || 'unknown'}`;
+  },
+});
+
+export { cleanupExpiredEntries, rateLimitStore };

--- a/backend/src/routes/health.ts
+++ b/backend/src/routes/health.ts
@@ -1,0 +1,154 @@
+import { Router, Request, Response } from 'express';
+import { pool } from '../config/database';
+
+const router = Router();
+
+router.get('/', async (req: Request, res: Response) => {
+  try {
+    const startTime = Date.now();
+    const client = await Promise.race([
+      pool.connect(),
+      new Promise<never>((_, reject) => 
+        setTimeout(() => reject(new Error('Database connection timeout')), 3000)
+      ),
+    ]);
+    const responseTime = Date.now() - startTime;
+    client.release();
+    
+    res.status(200).json({
+      status: 'healthy',
+      timestamp: new Date().toISOString(),
+    });
+  } catch (error) {
+    console.error('Health check failed:', error);
+    res.status(503).json({
+      status: 'unhealthy',
+      timestamp: new Date().toISOString(),
+      error: 'DATABASE_CONNECTION_FAILED',
+    });
+  }
+});
+
+router.get('/detailed', async (req: Request, res: Response) => {
+  const startTime = Date.now();
+  const health: any = {
+    status: 'healthy',
+    timestamp: new Date().toISOString(),
+    version: process.env.npm_package_version || '1.0.0',
+    uptime: process.uptime(),
+    services: {
+      database: 'unknown',
+      storage: 'connected',
+      memory: {
+        status: 'healthy',
+        used: 0,
+        total: 0,
+        percentage: 0,
+      },
+    },
+    checks: {},
+  };
+
+  let hasErrors = false;
+  let hasWarnings = false;
+
+  try {
+    const dbStartTime = Date.now();
+    const client = await Promise.race([
+      pool.connect(),
+      new Promise<never>((_, reject) => 
+        setTimeout(() => reject(new Error('Timeout')), 5000)
+      ),
+    ]);
+    const dbResponseTime = Date.now() - dbStartTime;
+    client.release();
+    
+    health.services.database = 'connected';
+    health.checks.database = {
+      status: 'ok',
+      responseTime: dbResponseTime,
+    };
+  } catch (error) {
+    hasErrors = true;
+    health.services.database = 'disconnected';
+    health.checks.database = {
+      status: 'error',
+      responseTime: Date.now() - startTime,
+      message: error instanceof Error ? error.message : 'Unknown error',
+    };
+  }
+
+  const memUsage = process.memoryUsage();
+  const totalMemory = require('os').totalmem();
+  const usedMemory = memUsage.heapUsed;
+  const memoryPercentage = (usedMemory / totalMemory) * 100;
+  
+  health.services.memory = {
+    status: memoryPercentage > 80 ? 'critical' : memoryPercentage > 60 ? 'warning' : 'healthy',
+    used: Math.round(usedMemory / 1024 / 1024),
+    total: Math.round(totalMemory / 1024 / 1024),
+    percentage: Math.round(memoryPercentage * 100) / 100,
+  };
+  
+  if (memoryPercentage > 80) {
+    hasErrors = true;
+    health.checks.memory = {
+      status: 'critical',
+      message: `Memory usage critical: ${memoryPercentage.toFixed(2)}%`,
+    };
+  } else if (memoryPercentage > 60) {
+    hasWarnings = true;
+    health.checks.memory = {
+      status: 'warning',
+      message: `Memory usage high: ${memoryPercentage.toFixed(2)}%`,
+    };
+  } else {
+    health.checks.memory = {
+      status: 'ok',
+      message: `Memory usage normal: ${memoryPercentage.toFixed(2)}%`,
+    };
+  }
+
+  if (hasErrors) {
+    health.status = 'unhealthy';
+  } else if (hasWarnings) {
+    health.status = 'degraded';
+  }
+
+  const statusCode = health.status === 'healthy' ? 200 : 
+                     health.status === 'degraded' ? 200 : 503;
+  
+  res.status(statusCode).json(health);
+});
+
+router.get('/live', (req: Request, res: Response) => {
+  res.status(200).json({
+    status: 'alive',
+    timestamp: new Date().toISOString(),
+  });
+});
+
+router.get('/ready', async (req: Request, res: Response) => {
+  try {
+    const client = await Promise.race([
+      pool.connect(),
+      new Promise<never>((_, reject) => 
+        setTimeout(() => reject(new Error('Timeout')), 2000)
+      ),
+    ]);
+    client.release();
+    
+    res.status(200).json({
+      status: 'ready',
+      timestamp: new Date().toISOString(),
+    });
+  } catch (error) {
+    res.status(503).json({
+      status: 'not_ready',
+      timestamp: new Date().toISOString(),
+      error: 'Database not available',
+    });
+  }
+});
+
+export default router;

--- a/pr-body.md
+++ b/pr-body.md
@@ -1,0 +1,84 @@
+## Backend Production Fixes
+
+This PR implements essential security and operational improvements for production deployment.
+
+### Changes Implemented
+
+#### 1. API Key Authentication (`middleware/auth.ts`)
+- Secure API key-based authentication
+- Support for `X-API-Key` and `Authorization: Bearer` headers
+- In-memory key storage (upgradeable to database)
+- Permission-based access control with `requirePermission` middleware
+- Optional authentication support
+- Health endpoints can optionally skip auth
+
+#### 2. Rate Limiting (`middleware/rateLimit.ts`)
+- Configurable rate limiting with window-based tracking
+- Per-route limiters: `apiRateLimiter`, `strictRateLimiter`, `uploadRateLimiter`, `authRateLimiter`, `healthRateLimiter`
+- Rate limit headers in responses: `X-RateLimit-Limit`, `X-RateLimit-Remaining`, `X-RateLimit-Reset`
+- Automatic cleanup of expired entries
+- Returns 429 status with retry information
+
+#### 3. Comprehensive Health Checks (`routes/health.ts`)
+- `/health` - Basic liveness check (for load balancers)
+- `/health/live` - Kubernetes liveness probe
+- `/health/ready` - Kubernetes readiness probe
+- `/health/detailed` - Full system status with database, memory, and service status
+
+#### 4. API Key Generation Script (`scripts/generate-api-key.js`)
+```bash
+node scripts/generate-api-key.js
+```
+
+#### 5. Test Suite (`__tests__/`)
+- `auth.test.ts` - Authentication middleware tests
+- `rateLimit.test.ts` - Rate limiting tests
+- `health.test.ts` - Health endpoint tests
+- `integration.test.ts` - Integration tests
+
+#### 6. Environment Configuration
+Updated `.env.example` with new required variables:
+```bash
+API_KEY=your_secure_api_key_here_min_32_characters
+RATE_LIMIT_WINDOW_MS=900000
+RATE_LIMIT_MAX_REQUESTS=100
+REQUIRE_AUTH_FOR_HEALTH=false
+```
+
+### Testing
+```bash
+# Run all tests
+npm test
+
+# Run with coverage
+npm run test:coverage
+
+# Generate new API key
+npm run generate-api-key
+```
+
+### Migration Guide
+
+1. Generate a new API key:
+   ```bash
+   cd backend && npm run generate-api-key
+   ```
+
+2. Add API_KEY to your `.env` file (minimum 32 characters)
+
+3. Update your API clients to include the header:
+   ```
+   X-API-Key: your-api-key-here
+   # or
+   Authorization: Bearer your-api-key-here
+   ```
+
+4. Health endpoints remain public by default (disable with `REQUIRE_AUTH_FOR_HEALTH=true`)
+
+### Security Considerations
+- API keys must be at least 32 characters
+- Rate limiting prevents DDoS and brute force attacks
+- Health endpoints can be protected if needed
+- In-memory key storage is suitable for single-instance deployments; use Redis/database for multi-instance
+
+Closes #76


### PR DESCRIPTION
## Backend Production Fixes

This PR implements essential security and operational improvements for production deployment.

### Changes Implemented

#### 1. API Key Authentication (`middleware/auth.ts`)
- Secure API key-based authentication
- Support for `X-API-Key` and `Authorization: Bearer` headers
- In-memory key storage (upgradeable to database)
- Permission-based access control with `requirePermission` middleware
- Optional authentication support
- Health endpoints can optionally skip auth

#### 2. Rate Limiting (`middleware/rateLimit.ts`)
- Configurable rate limiting with window-based tracking
- Per-route limiters: `apiRateLimiter`, `strictRateLimiter`, `uploadRateLimiter`, `authRateLimiter`, `healthRateLimiter`
- Rate limit headers in responses: `X-RateLimit-Limit`, `X-RateLimit-Remaining`, `X-RateLimit-Reset`
- Automatic cleanup of expired entries
- Returns 429 status with retry information

#### 3. Comprehensive Health Checks (`routes/health.ts`)
- `/health` - Basic liveness check (for load balancers)
- `/health/live` - Kubernetes liveness probe
- `/health/ready` - Kubernetes readiness probe
- `/health/detailed` - Full system status with database, memory, and service status

#### 4. API Key Generation Script (`scripts/generate-api-key.js`)
```bash
node scripts/generate-api-key.js
```

#### 5. Test Suite (`__tests__/`)
- `auth.test.ts` - Authentication middleware tests
- `rateLimit.test.ts` - Rate limiting tests
- `health.test.ts` - Health endpoint tests
- `integration.test.ts` - Integration tests

#### 6. Environment Configuration
Updated `.env.example` with new required variables:
```bash
API_KEY=your_secure_api_key_here_min_32_characters
RATE_LIMIT_WINDOW_MS=900000
RATE_LIMIT_MAX_REQUESTS=100
REQUIRE_AUTH_FOR_HEALTH=false
```

### Testing
```bash
# Run all tests
npm test

# Run with coverage
npm run test:coverage

# Generate new API key
npm run generate-api-key
```

### Migration Guide

1. Generate a new API key:
   ```bash
   cd backend && npm run generate-api-key
   ```

2. Add API_KEY to your `.env` file (minimum 32 characters)

3. Update your API clients to include the header:
   ```
   X-API-Key: your-api-key-here
   # or
   Authorization: Bearer your-api-key-here
   ```

4. Health endpoints remain public by default (disable with `REQUIRE_AUTH_FOR_HEALTH=true`)

### Security Considerations
- API keys must be at least 32 characters
- Rate limiting prevents DDoS and brute force attacks
- Health endpoints can be protected if needed
- In-memory key storage is suitable for single-instance deployments; use Redis/database for multi-instance

Closes #76
