### PR TITLE
fix: complete dark mode integration

### DIFF
--- a/mobile/App.tsx
+++ b/mobile/App.tsx
@@ -13,10 +13,10 @@ import { migrateStorageData, useAppStore } from './src/stores';
 import { RootNavigator } from './src/navigation';
 
 // Loading Screen während Initialisierung
-const LoadingScreen = () => (
-  <View style={{ flex: 1, justifyContent: 'center', alignItems: 'center', backgroundColor: '#FFFFFF' }}>
-    <ActivityIndicator size="large" color="#4CAF50" />
-    <Text style={{ marginTop: 16, color: '#666' }}>Tauben Scanner wird gestartet...</Text>
+const LoadingScreen = ({ theme }: { theme: typeof paperLightTheme }) => (
+  <View style={{ flex: 1, justifyContent: 'center', alignItems: 'center', backgroundColor: theme.colors.background }}>
+    <ActivityIndicator size="large" color={theme.colors.success} />
+    <Text style={{ marginTop: 16, color: theme.colors.onSurfaceVariant }}>Tauben Scanner wird gestartet...</Text>
   </View>
 );
 
@@ -105,7 +105,7 @@ export default function App() {
   }, [requestAllPermissions, setOnlineStatus]);
 
   if (!isReady) {
-    return <LoadingScreen />;
+    return <LoadingScreen theme={theme} />;
   }
 
   return (

--- a/mobile/src/screens/debug/DebugApiTest.tsx
+++ b/mobile/src/screens/debug/DebugApiTest.tsx
@@ -7,7 +7,7 @@ import { useSettingsStore } from '../../stores/settings';
 import { clearStorage, createMmkvStorage, StorageKeys } from '../../stores/storage';
 import { useTheme } from "../../theme";
 
-export const DebugApiTest = () => {
+export const DebugApiTest: React.FC = () => {
   const theme = useTheme();
   const [manualTest, setManualTest] = useState<any>(null);
   const [loading, setLoading] = useState(false);
@@ -47,36 +47,50 @@ export const DebugApiTest = () => {
 
   return (
     <ScrollView style={[styles.container, { backgroundColor: theme.colors.background }]}>
-      <Text variant="headlineMedium" style={styles.title}>🔧 Debug API Test</Text>
+      <Text variant="headlineMedium" style={[styles.title, { color: theme.colors.onSurface }]}>🔧 Debug API Test</Text>
       
-      <Text style={styles.section}>API URL:</Text>
-      <Text variant="bodyLarge" style={styles.value}>{apiUrl}</Text>
+      <Text style={[styles.section, { color: theme.colors.onSurfaceVariant }]}>API URL:</Text>
+      <Text 
+        variant="bodyLarge" 
+        style={[styles.value, { 
+          backgroundColor: theme.colors.surface,
+          color: theme.colors.onSurface 
+        }]}
+      >
+        {apiUrl}
+      </Text>
 
-      <Text style={styles.section}>React Query Hook:</Text>
-      <Text>isLoading: {String(isLoading)}</Text>
-      <Text>isError: {String(isError)}</Text>
-      <Text>error: {queryError ? JSON.stringify(queryError, null, 2) : 'none'}</Text>
-      <Text>data: {data ? JSON.stringify(data, null, 2).slice(0, 500) + '...' : 'null'}</Text>
+      <Text style={[styles.section, { color: theme.colors.onSurfaceVariant }]}>React Query Hook:</Text>
+      <Text style={{ color: theme.colors.onSurface }}>isLoading: {String(isLoading)}</Text>
+      <Text style={{ color: theme.colors.onSurface }}>isError: {String(isError)}</Text>
+      <Text style={{ color: theme.colors.onSurface }}>error: {queryError ? JSON.stringify(queryError, null, 2) : 'none'}</Text>
+      <Text style={{ color: theme.colors.onSurface }}>data: {data ? JSON.stringify(data, null, 2).slice(0, 500) + '...' : 'null'}</Text>
 
-      <Text style={styles.section}>Manual API Test:</Text>
+      <Text style={[styles.section, { color: theme.colors.onSurfaceVariant }]}>Manual API Test:</Text>
       <Button title={loading ? "Testing..." : "Test API Call"} onPress={testManual} disabled={loading} />
       
       {manualTest && (
-        <View style={styles.resultBox}>
-          <Text style={{ color: 'green' }}>✅ Success!</Text>
-          <Text>{JSON.stringify(manualTest, null, 2).slice(0, 1000)}</Text>
+        <View style={[styles.resultBox, { 
+          backgroundColor: theme.colors.surface,
+          borderColor: theme.colors.success 
+        }]}>
+          <Text style={{ color: theme.colors.success }}>✅ Success!</Text>
+          <Text style={{ color: theme.colors.onSurface }}>{JSON.stringify(manualTest, null, 2).slice(0, 1000)}</Text>
         </View>
       )}
 
       {error && (
-        <View style={[styles.resultBox, { borderColor: 'red' }]}>
-          <Text style={{ color: 'red' }}>❌ Error: {error}</Text>
+        <View style={[styles.resultBox, { 
+          backgroundColor: theme.colors.surface,
+          borderColor: theme.colors.error 
+        }]}>
+          <Text style={{ color: theme.colors.error }}>❌ Error: {error}</Text>
         </View>
       )}
 
-      <Text style={styles.section}>Storage Actions:</Text>
+      <Text style={[styles.section, { color: theme.colors.onSurfaceVariant }]}>Storage Actions:</Text>
       <View style={styles.buttonGap}>
-        <Button title="Clear Storage" onPress={clearCache} color="red" />
+        <Button title="Clear Storage" onPress={clearCache} color={theme.colors.error} />
       </View>
       <View style={styles.buttonGap}>
         <Button title="Reset Settings" onPress={resetSettings} />
@@ -92,7 +106,6 @@ const styles = StyleSheet.create({
   container: {
     flex: 1,
     padding: 16,
-    backgroundColor: '#fff',
   },
   title: {
     marginBottom: 20,
@@ -103,10 +116,8 @@ const styles = StyleSheet.create({
     marginBottom: 10,
     fontWeight: 'bold',
     fontSize: 16,
-    color: '#333',
   },
   value: {
-    backgroundColor: '#f0f0f0',
     padding: 8,
     borderRadius: 4,
   },
@@ -114,11 +125,11 @@ const styles = StyleSheet.create({
     marginTop: 10,
     padding: 10,
     borderWidth: 1,
-    borderColor: '#4CAF50',
     borderRadius: 4,
-    backgroundColor: '#f9f9f9',
   },
   buttonGap: {
     marginVertical: 5,
   },
 });
+
+export default DebugApiTest;

--- a/mobile/src/screens/settings/SettingsScreen.tsx
+++ b/mobile/src/screens/settings/SettingsScreen.tsx
@@ -169,7 +169,7 @@ export const SettingsScreen: React.FC = () => {
       
       {showSaved && (
         <View style={[styles.savedBanner, { backgroundColor: theme.colors.success as string }]}>
-          <Text variant="caption" style={{ color: '#fff', textAlign: 'center' }}>
+          <Text variant="caption" style={{ color: theme.colors.onPrimary, textAlign: 'center' }}>
             Gespeichert!
           </Text>
         </View>


### PR DESCRIPTION
## Summary
Completes dark mode integration by fixing remaining hardcoded colors.

## Changes
- **mobile/App.tsx**: Fixed LoadingScreen to use theme colors (background, success, onSurfaceVariant) instead of hardcoded '#FFFFFF', '#4CAF50', '#666'
- **screens/debug/DebugApiTest.tsx**: Fixed all hardcoded colors:
  - '#fff' → theme.colors.background for container
  - '#f0f0f0' → theme.colors.surface for value boxes
  - '#f9f9f9' → theme.colors.surface for result boxes
  - '#333' → theme.colors.onSurfaceVariant for section headers
  - 'green'/'red' → theme.colors.success/error for status messages
- **screens/settings/SettingsScreen.tsx**: Fixed saved banner text color from '#fff' to theme.colors.onPrimary

## Verification
✅ No remaining hardcoded background colors in non-camera components
✅ No remaining hardcoded text colors (#666, #333) in screens
✅ All components now use theme-aware colors
✅ Camera components left unchanged (white colors intentional for overlay visibility)

Closes #74