### PR TITLE
fix: Complete dark mode - navigation bar and backgrounds (#95)

### DIFF
--- a/mobile/App.tsx
+++ b/mobile/App.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useState, useCallback } from 'react';
-import { View, ActivityIndicator, useColorScheme, StatusBar, Alert, Linking } from 'react-native';
+import { View, ActivityIndicator, useColorScheme, StatusBar, Alert, Linking, Platform } from 'react-native';
 import { SafeAreaProvider } from 'react-native-safe-area-context';
 import { Provider as PaperProvider, Text } from 'react-native-paper';
 import { QueryClientProvider } from '@tanstack/react-query';
@@ -7,6 +7,7 @@ import NetInfo from '@react-native-community/netinfo';
 import { useCameraPermissions } from 'expo-camera';
 import * as Location from 'expo-location';
 import * as ImagePicker from 'expo-image-picker';
+import * as NavigationBar from 'expo-navigation-bar';
 import { queryClient } from './src/services/queryClient';
 import { paperLightTheme, paperDarkTheme } from './src/theme/paperTheme';
 import { migrateStorageData, useAppStore } from './src/stores';
@@ -25,6 +26,15 @@ export default function App() {
   const { setOnlineStatus } = useAppStore();
   const colorScheme = useColorScheme();
   const theme = colorScheme === 'dark' ? paperDarkTheme : paperLightTheme;
+
+  // Android Navigation Bar styling
+  useEffect(() => {
+    if (Platform.OS === "android") {
+      NavigationBar.setBackgroundColorAsync(theme.colors.background);
+      NavigationBar.setButtonStyleAsync(colorScheme === "dark" ? "light" : "dark");
+    }
+  }, [theme, colorScheme]);
+
   
   // Camera permission hook
   const [cameraPermission, requestCameraPermission] = useCameraPermissions();

--- a/mobile/package-lock.json
+++ b/mobile/package-lock.json
@@ -28,6 +28,7 @@
         "expo-image-picker": "~16.0.0",
         "expo-location": "~18.0.0",
         "expo-media-library": "~17.0.6",
+        "expo-navigation-bar": "^55.0.8",
         "expo-status-bar": "~2.0.0",
         "react": "^18.3.1",
         "react-hook-form": "^7.71.2",
@@ -6992,6 +6993,21 @@
         "invariant": "^2.2.4"
       }
     },
+    "node_modules/expo-navigation-bar": {
+      "version": "55.0.8",
+      "resolved": "https://registry.npmjs.org/expo-navigation-bar/-/expo-navigation-bar-55.0.8.tgz",
+      "integrity": "sha512-3Wa7m1zXuuH7FjwvwBR44ZRW+Ixn/GxS2anUCiWXFdPXjKLIYtAtr37vJ2c3KgFqNyhRlg1sgFawk4A8V5swhg==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.3.2",
+        "react-native-is-edge-to-edge": "^1.2.1"
+      },
+      "peerDependencies": {
+        "expo": "*",
+        "react": "*",
+        "react-native": "*"
+      }
+    },
     "node_modules/expo-status-bar": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/expo-status-bar/-/expo-status-bar-2.0.1.tgz",
@@ -11906,6 +11922,16 @@
         "invariant": "^2.2.4",
         "prop-types": "^15.7.2"
       },
+      "peerDependencies": {
+        "react": "*",
+        "react-native": "*"
+      }
+    },
+    "node_modules/react-native-is-edge-to-edge": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/react-native-is-edge-to-edge/-/react-native-is-edge-to-edge-1.2.1.tgz",
+      "integrity": "sha512-FLbPWl/MyYQWz+KwqOZsSyj2JmLKglHatd3xLZWskXOpRaio4LfEDEz8E/A6uD8QoTHW6Aobw1jbEwK7KMgR7Q==",
+      "license": "MIT",
       "peerDependencies": {
         "react": "*",
         "react-native": "*"

--- a/mobile/package.json
+++ b/mobile/package.json
@@ -34,6 +34,7 @@
     "expo-image-picker": "~16.0.0",
     "expo-location": "~18.0.0",
     "expo-media-library": "~17.0.6",
+    "expo-navigation-bar": "^55.0.8",
     "expo-status-bar": "~2.0.0",
     "react": "^18.3.1",
     "react-hook-form": "^7.71.2",

--- a/mobile/src/navigation/RootNavigator.tsx
+++ b/mobile/src/navigation/RootNavigator.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
-import { NavigationContainer } from '@react-navigation/native';
+import { NavigationContainer } from "@react-navigation/native";
+import { useTheme } from "react-native-paper";
 import { createNativeStackNavigator } from '@react-navigation/native-stack';
 import { useOnboardingCompleted } from '../stores/app';
 import { OnboardingScreen } from '../screens/onboarding';
@@ -9,11 +10,17 @@ import type { RootStackParamList } from './types';
 const Stack = createNativeStackNavigator<RootStackParamList>();
 
 export const RootNavigator: React.FC = () => {
+  const theme = useTheme();
   const onboardingCompleted = useOnboardingCompleted();
 
   return (
     <NavigationContainer>
-      <Stack.Navigator screenOptions={{ headerShown: false }}>
+      <Stack.Navigator screenOptions={{
+        headerShown: false,
+        contentStyle: {
+          backgroundColor: theme.colors.background,
+        },
+      }}>
         {!onboardingCompleted && (
           <Stack.Screen name="Onboarding" component={OnboardingScreen} />
         )}

--- a/mobile/src/navigation/TabNavigator.tsx
+++ b/mobile/src/navigation/TabNavigator.tsx
@@ -38,6 +38,9 @@ export const TabNavigator: React.FC = () => {
           backgroundColor: theme.colors.surface,
           borderTopColor: theme.colors.outline,
         },
+        sceneContainerStyle: {
+          backgroundColor: theme.colors.background,
+        },
         tabBarLabelStyle: {
           fontSize: 12,
           fontWeight: '500',

--- a/mobile/src/screens/scan/ResultsScreen.tsx
+++ b/mobile/src/screens/scan/ResultsScreen.tsx
@@ -177,8 +177,8 @@ export const ResultsScreen: React.FC = () => {
         {/* Kein Match */}
         {!result.pigeon && (
           <Card style={[styles.noMatchCard, { 
-            backgroundColor: isDark ? theme.colors.surface : '#FFF8E1',
-            borderColor: isDark ? theme.colors.outline : '#FFE0B2'
+            backgroundColor: theme.colors.surface,
+            borderColor: theme.colors.outline
           }]}>
             <Card.Content>
               <Text variant="titleMedium" style={{ textAlign: 'center', marginBottom: 8, color: theme.colors.onSurface }}>


### PR DESCRIPTION
## Changes
- Add expo-navigation-bar for Android
- Dynamic navigation bar theming (follows app theme)
- Fix ResultsScreen hardcoded colors
- Fix RootNavigator background colors
- Fix TabNavigator background colors

## Android Navigation Bar
- Dark mode: dark background + light buttons
- Light mode: light background + dark buttons

## Issues
Fixes #95