### PR TITLE
fix(splash): add dark mode support

### DIFF
--- a/mobile/app.json
+++ b/mobile/app.json
@@ -5,12 +5,15 @@
     "version": "1.0.1",
     "orientation": "portrait",
     "icon": "./assets/icon.png",
-    "userInterfaceStyle": "light",
+    "userInterfaceStyle": "automatic",
     "backgroundColor": "#FFFFFF",
     "splash": {
       "image": "./assets/splash-icon.png",
       "resizeMode": "contain",
-      "backgroundColor": "#FFFFFF"
+      "backgroundColor": "#FFFFFF",
+      "dark": {
+        "backgroundColor": "#121212"
+      }
     },
     "ios": {
       "supportsTablet": true,
@@ -61,7 +64,6 @@
           "photosPermission": "Die App benötigt Zugriff auf Ihre Fotos, um Taubenbilder hochzuladen."
         }
       ]
-    ],
-
+    ]
   }
 }


### PR DESCRIPTION
## Changes
- Change userInterfaceStyle from 'light' to 'automatic'
- Add dark.backgroundColor: '#121212' to splash config
- Enable system-adaptive splash screen behavior

## Testing Checklist
- [ ] Test on Android with dark system theme
- [ ] Test on iOS with dark system theme

Fixes #124